### PR TITLE
fix: Markdown format

### DIFF
--- a/docs/bridge_dongle.md
+++ b/docs/bridge_dongle.md
@@ -1,4 +1,4 @@
-#BLE-USB HIDブリッジドングル
+# BLE-USB HIDブリッジドングル
 
 (開発中)BLE Micro ProやMDBT50Q-RXを使って、BLEとUSBのHIDをブリッジします。
 ```


### PR DESCRIPTION
Markdownの書式がgithub.ioで有効になっていませんでした。