### PR TITLE
config_converterで式で定義されたcol_num, row_numも扱えるように修正

### DIFF
--- a/AboutDefaultFirmware/keyboards/config_converter.py
+++ b/AboutDefaultFirmware/keyboards/config_converter.py
@@ -262,11 +262,11 @@ class ConfigConverter:
             print(red('ERROR') + ': Failed to find MATRIX_ROWS')
             res = False
 
-        if (int(self.col_num) != len(self.col_pins.split(',')) or int(self.row_num) != len(self.row_pins.split(','))):
+        if (int(eval(self.col_num)) != len(self.col_pins.split(',')) or int(eval(self.row_num)) != len(self.row_pins.split(','))):
             self.is_split = True
             print('This keyboard is split keyboard')
 
-        if (int(self.col_num) != len(self.col_pins.split(',')) and int(self.row_num) != len(self.row_pins.split(','))):
+        if (int(eval(self.col_num)) != len(self.col_pins.split(',')) and int(eval(self.row_num)) != len(self.row_pins.split(','))):
             print(yellow('warning') +
                   ': MATRIX len and PINS len do not match in both row and col.')
 
@@ -368,7 +368,7 @@ if __name__ == '__main__':
     with open(config_name, 'w') as f:
         f.write(
             config_file_format.format(
-                config.vid, config.pid, config.name, config.manufacture, config.description, config.row_num, config.col_num, len(
+                config.vid, config.pid, config.name, config.manufacture, config.description, eval(config.row_num), eval(config.col_num), len(
                     config.row_pins.split(',')), len(config.col_pins.split(',')), config.diode_direction, config.row_pins, config.col_pins,
                 config.layout.replace(
                     '\n', '\n\t\t\t'), mode, config.led_pin, config.led_num


### PR DESCRIPTION
Keyball61で設定ファイルを生成しようとして発見。

下記のようなパターンだとエラーが発生する。
https://github.com/Yowkees/keyball/blob/main/qmk_firmware/keyboards/keyball/keyball61/config.h#L31-L32

エラー
```
 ** Making config.json from ./keyball/qmk_firmware/keyboards/keyball/keyball61 **
0: LAYOUT_right_ball		keyball/keyball61/keyball61.h:26
1: LAYOUT_left_ball		keyball/keyball61/keyball61.h:46
2: LAYOUT_dual_ball		keyball/keyball61/keyball61.h:66
3: LAYOUT_no_ball		keyball/keyball61/keyball61.h:86
4: LAYOUT		keyball/keyball61/keyball61.h:108
5: LAYOUT_universal		keyball/keyball61/keyball61.h:109

Use layout: 4
ERROR: Failed to find LAYOUT
Traceback (most recent call last):
  File "./BLE-Micro-Pro/AboutDefaultFirmware/keyboards/config_converter.py", line 338, in <module>
    if not config.assertion():
  File "./BLE-Micro-Pro/AboutDefaultFirmware/keyboards/config_converter.py", line 265, in assertion
    if (int(self.col_num) != len(self.col_pins.split(',')) or int(self.row_num) != len(self.row_pins.split(','))):
ValueError: invalid literal for int() with base 10: '(4 * 2)'
```
